### PR TITLE
Remove comment imposter.

### DIFF
--- a/core/sysprop.mk
+++ b/core/sysprop.mk
@@ -48,7 +48,6 @@ define generate-common-build-props
         echo "ro.product.$(1).manufacturer=$(PRODUCT_MANUFACTURER)" >> $(2);\
         echo "ro.product.$(1).model=$${PRODUCT_MODEL:-$(PRODUCT_MODEL)}" >> $(2);\
         echo "ro.product.$(1).name=$${TARGET_PRODUCT:-$(TARGET_PRODUCT)}" >> $(2);\
-        # Attestation specific properties for AOSP/GSI build running on device.
         if [ -n "$(strip $(PRODUCT_MODEL_FOR_ATTESTATION))" ]; then \
             echo "ro.product.model_for_attestation=$(PRODUCT_MODEL_FOR_ATTESTATION)" >> $(2);\
         fi; \


### PR DESCRIPTION
Removes a line of code, that looks like a comment but is an block of code.
Causes this issue


2024-03-10 09:55:51 - check_target_files_vintf.py - INFO    : stderr: 
Traceback (most recent call last):
  File "internal/stdlib/runpy.py", line 196, in _run_module_as_main
  File "internal/stdlib/runpy.py", line 86, in _run_code
  File "/home/need/h/out/host/linux-x86/bin/ota_from_target_files/__main__.py", line 12, in <module>
  File "internal/stdlib/runpy.py", line 196, in _run_module_as_main
  File "internal/stdlib/runpy.py", line 86, in _run_code
  File "ota_from_target_files.py", line 1455, in <module>
  File "ota_from_target_files.py", line 1426, in main
  File "ota_from_target_files.py", line 983, in GenerateAbOtaPackage
  File "ota_utils.py", line 285, in GetPackageMetadata
  File "ota_utils.py", line 247, in UpdateDeviceState
  File "ota_utils.py", line 236, in UpdatePartitionStates
  File "common.py", line 542, in GetPartitionBuildProp
common.ExternalError: couldn't find ro.bootimage.build.date.utc in boot.build.prop
